### PR TITLE
delete import preview icon from EditorHeader.jsx

### DIFF
--- a/client/src/component/editor/EditorHeader.jsx
+++ b/client/src/component/editor/EditorHeader.jsx
@@ -10,9 +10,9 @@ import Tooltip from "@mui/material/Tooltip";
 import SaveIcon from "@mui/icons-material/Save";
 import LogoutIcon from "@mui/icons-material/Logout";
 import Logo from "../../assets/WIME-logo.png"
-import PreviewIcon from "@mui/icons-material/Preview";
-import { Container } from "@mui/material";
 import VisibilityIcon from '@mui/icons-material/Visibility';
+import { Container } from "@mui/material";
+
 
 
 


### PR DESCRIPTION
removed the importing of preview icon from mui, in EditorHeader.jsx